### PR TITLE
Fix PR9 so that it will compile when added to Godot master.

### DIFF
--- a/sqlite.cpp
+++ b/sqlite.cpp
@@ -35,13 +35,14 @@ Array fast_parse_row(sqlite3_stmt *stmt) {
 				PackedByteArray arr;
 				int size = sqlite3_column_bytes(stmt, i);
 				arr.resize(size);
-				memcpy(arr.ptrw(), sqlite3_column_blob(stmt, i), size);
+				memcpy((void *)arr.ptr(), sqlite3_column_blob(stmt, i), size);
 				value = Variant(arr);
 				break;
 			}
 			case SQLITE_NULL: {
 				// Nothing to do.
-                        } break;
+				break;
+			}
 			default:
 				ERR_PRINT("This kind of data is not yet supported: " + itos(col_type));
 				break;
@@ -149,7 +150,6 @@ Array SQLiteQuery::get_columns() {
 }
 
 bool SQLiteQuery::prepare() {
-
 	ERR_FAIL_COND_V(stmt != nullptr, false);
 	ERR_FAIL_COND_V(db == nullptr, false);
 	ERR_FAIL_COND_V(query == "", false);


### PR DESCRIPTION
Currently this [PR](https://github.com/godot-extended-libraries/godot-sqlite/pull/9) does not compile when added to Godot 4 `master`. This PR makes the minimal changes required to enable this to compile and pass the `clangformat` checks; so that it can be used.