### PR TITLE
Fix PR8 so that it will compile when added to Godot 3.2 branch.

### DIFF
--- a/sqlite.cpp
+++ b/sqlite.cpp
@@ -175,7 +175,7 @@ void SQLiteQuery::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_last_error_message"), &SQLiteQuery::get_last_error_message);
 	ClassDB::bind_method(D_METHOD("execute", "arguments"), &SQLiteQuery::execute, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("batch_execute", "rows"), &SQLiteQuery::batch_execute);
-	ClassDB::bind_method(D_METHOD("get_columns"), &SQLiteQuery::get_columns)
+	ClassDB::bind_method(D_METHOD("get_columns"), &SQLiteQuery::get_columns);
 }
 
 SQLite::SQLite() {

--- a/sqlite.h
+++ b/sqlite.h
@@ -67,7 +67,7 @@ public:
 	Variant batch_execute(Array p_rows);
 
 	/// Return the list of columns of this query.
-	Array get_columns()
+	Array get_columns();
 
 	void finalize();
 


### PR DESCRIPTION
Currently this [PR](https://github.com/godot-extended-libraries/godot-sqlite/pull/8) does not compile when added to Godot 3.2 branch. This PR makes the minimal changes required to enable this to compile; so that it can be used.